### PR TITLE
Update API for mcmc to fix M-H step bug.

### DIFF
--- a/examples/deep/mnist/mnist_mcmc.py
+++ b/examples/deep/mnist/mnist_mcmc.py
@@ -1,0 +1,206 @@
+import haiku as hk
+
+import jax.numpy as jnp
+from jax.experimental import optimizers
+import jax
+
+import jax_bayes
+from jax_bayes.mcmc import mala_fns
+
+import sys, os, math, time
+import numpy as np
+from tqdm import trange
+
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2' 
+import tensorflow_datasets as tfds
+
+from matplotlib import pyplot as plt
+
+#load the data and create the model
+def load_dataset(split, is_training, batch_size):
+    ds = tfds.load('mnist:3.*.*', split=split).cache().repeat()
+    if is_training:
+        ds = ds.shuffle(10 * batch_size, seed=0)
+    ds = ds.batch(batch_size)
+    return iter(tfds.as_numpy(ds))
+
+def net_fn(batch):
+    """ Standard LeNet-300-100 MLP """
+    x = batch["image"].astype(jnp.float32) / 255.
+
+    # we initialize the model with zeros since we're going to construct intiial 
+    # samples for the weights with additive Gaussian noise
+    sig = 0.0
+    mlp = hk.Sequential([
+        hk.Flatten(),
+        hk.Linear(300, w_init=hk.initializers.RandomNormal(stddev=sig),
+                       b_init=hk.initializers.RandomNormal(stddev=sig)), 
+        jax.nn.relu, 
+        hk.Linear(100, w_init=hk.initializers.RandomNormal(stddev=sig),
+                       b_init=hk.initializers.RandomNormal(stddev=sig)), 
+        jax.nn.relu, 
+        hk.Linear(10,  w_init=hk.initializers.RandomNormal(stddev=sig),
+                       b_init=hk.initializers.RandomNormal(stddev=sig))
+        ])
+
+    return mlp(x)
+
+
+def main():
+    #hyperparameters
+    lr = 5e-3
+    # lr = 1e-3
+    reg = 1e-4
+    num_samples = 100 # number of samples to approximate the posterior
+    init_stddev = 5.0 # initial distribution for the samples will be N(0, 0.1)
+    train_batch_size = 1_000
+    eval_batch_size = 10_000
+
+    #instantiate the model --- same as regular case
+    net = hk.transform(net_fn)
+
+    #build the sampler instead of optimizer
+    sampler_fns = mala_fns
+    seed = 0
+    key = jax.random.PRNGKey(seed)
+    sampler_init, sampler_propose, sampler_accept, sampler_update, sampler_get_params = \
+        sampler_fns(key, num_samples=num_samples, step_size=lr, init_stddev=init_stddev,
+        noise_scale=0.1)
+
+
+    # loss is the same as the regular case! This is because in regular ML, we're minimizing
+    # the negative log-posterior logP(params | data) = logP(data | params) + logP(params) + constant
+    # i.e. finding the MAP estimate.
+    def loss(params, batch):
+        logits = net.apply(params, jax.random.PRNGKey(0), batch)
+        labels = jax.nn.one_hot(batch['label'], 10)
+        l2_loss = 0.5 * sum(jnp.sum(jnp.square(p)) 
+                    for p in jax.tree_leaves(params))
+        softmax_crossent = - jnp.mean(labels * jax.nn.log_softmax(logits))
+
+        return softmax_crossent + reg * l2_loss
+
+    #the log-probability is the negative of the loss
+    logprob = lambda p,b : - loss(p, b)
+
+    @jax.jit
+    def accuracy(params, batch):
+        #auto-vectorize over the samples of params! only in JAX...
+        pred_fn = jax.vmap(net.apply, in_axes=(0, None, None))
+
+        # this is crucial --- integrate (i.e. average) out the parameters
+        all_logits = pred_fn(params, None, batch)
+        probs = jnp.mean(jax.nn.softmax(all_logits, axis=-1), axis=0)
+
+        return jnp.mean(jnp.argmax(probs, axis=-1) == batch['label'])
+
+    #build the mcmc step. This is like the opimization step, but for sampling
+    @jax.jit
+    def mcmc_step(i, state, keys, batch):
+        #extract parameters
+        params = sampler_get_params(state)
+        # rvals = sampler_get_params(state, idx=1)
+        
+        #form a partial eval of logprob on the data
+        logp = lambda p: logprob(p,  batch) #can make this 1-line?
+        
+        # evaluate *per-sample* gradients
+        fx, dx = jax.vmap(jax.value_and_grad(logp))(params)
+
+        # generat proposal states for the Markov chains
+        prop_state, new_keys = sampler_propose(i, dx, state, keys)
+        
+        #we don't need to re-compute gradients for the accept stage
+        prop_params = sampler_get_params(prop_state)
+        fx_prop, dx_prop = jax.vmap(jax.value_and_grad(logp))(prop_params)
+
+        # generate the acceptance indices from the Metropolis-Hastings
+        # accept-reject step
+        accept_idxs, keys = sampler_accept(
+            i, fx, fx_prop, dx, state, dx_prop, prop_state, keys
+        )
+
+        # update the sampler state based on the acceptance acceptance indices
+        state, keys = sampler_update(
+            i, accept_idxs, dx, state, dx_prop, prop_state, keys
+        )
+        
+        return fx, state, new_keys
+
+    # load the data into memory and create batch iterators
+    train_batches = load_dataset("train", is_training=True, batch_size=train_batch_size)
+    val_batches = load_dataset("train", is_training=False, batch_size=eval_batch_size)
+    test_batches = load_dataset("test", is_training=False, batch_size=eval_batch_size)
+
+
+    #get a single sample of the params using the normal hk.init(...)
+    params = net.init(jax.random.PRNGKey(42), next(train_batches))
+
+    # get a SamplerState object with `num_samples` params along dimension 0
+    # generated by adding Gaussian noise (see sampler_fns(..., init_dist='normal'))
+    sampler_state, sampler_keys = sampler_init(params)
+
+    # iterate the the Markov chain
+    for step in trange(2_501):
+        train_logprobs, sampler_state, sampler_keys = \
+            mcmc_step(step, sampler_state, sampler_keys, next(train_batches))
+    
+        if step % 500 == 0:
+            params = sampler_get_params(sampler_state)
+            val_acc = accuracy(params, next(val_batches))
+            test_acc = accuracy(params, next(test_batches))
+            print(f"step = {step}"
+                f" | val acc = {val_acc:.3f}"
+                f" | test acc = {test_acc:.3f}")
+    
+    def posterior_predictive(params, batch):
+        pred_fn = lambda p:net.apply(p, None, batch) 
+        pred_fn = jax.vmap(pred_fn)
+
+        logit_samples = pred_fn(params) # n_samples x batch_size x n_classes
+        pred_samples = jnp.argmax(logit_samples, axis=-1) #n_samples x batch_size
+
+        n_classes = logit_samples.shape[-1]
+        batch_size = logit_samples.shape[1]
+        probs = np.zeros((batch_size, n_classes))
+        for c in range(n_classes):
+            idxs = pred_samples == c
+            probs[:,c] = idxs.sum(axis=0)
+
+        return probs / probs.sum(axis=1, keepdims=True)
+
+
+    def do_analysis():
+        test_data = next(test_batches)
+        pred_fn = jax.vmap(net.apply, in_axes=(0, None, None))
+
+        all_test_logits = pred_fn(params, None, test_data)
+        probs = jnp.mean(jax.nn.softmax(all_test_logits, axis=-1), axis=0)
+        correct_preds_mask = jnp.argmax(probs, axis=-1) == test_data['label']
+
+        # pp = posterior_predictive(params, test_data)
+        pp = probs
+        entropies = jax_bayes.utils.entropy(pp)
+
+        correct_ent = entropies[correct_preds_mask]
+        incorrect_ent = entropies[~correct_preds_mask]
+
+        mean_correct_ent = jnp.mean(correct_ent)
+        mean_incorrect_ent = jnp.mean(incorrect_ent)
+
+        plt.hist(correct_ent, alpha=0.3, label='correct', density=True)
+        plt.hist(incorrect_ent, alpha=0.3, label='incorrect', density=True)
+        plt.axvline(x=mean_correct_ent, color='blue', label='mean correct')
+        plt.axvline(x=mean_incorrect_ent, color='orange', label='mean incorrect')
+        plt.legend()
+        plt.xlabel("entropy")
+        plt.ylabel("histogram density")
+        plt.title("posterior predictive entropy of correct vs incorrect predictions")
+        plt.show()
+
+    do_analysis()
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/shallow/mcmc_1d.py
+++ b/examples/shallow/mcmc_1d.py
@@ -5,13 +5,19 @@ import jax
 
 from copy import copy, deepcopy
 import itertools, math
-import datetime as dt
+import time
 from matplotlib import pyplot as plt
 import seaborn as sns
 
-from jax_bayes.mcmc import (langevin_fns, mala_fns, rk_langevin_fns, hmc_fns,
-							 rwmh_fns, rms_langevin_fns)
-from jax_bayes.mcmc import bb_mcmc
+from jax_bayes.mcmc import (
+	langevin_fns,
+	mala_fns,
+	rk_langevin_fns,
+	hmc_fns,
+	rms_langevin_fns,
+	rwmh_fns
+)
+from jax_bayes.mcmc import blackbox_mcmc as bb_mcmc
 
 @jax.jit 
 def bimodal_logprob(z):
@@ -30,60 +36,79 @@ def main():
 	
 	#====== Tests =======
 
-	t = dt.datetime.now()
+	t = time.time()
 	print('running 1d tests ...')
-	samps = bb_mcmc(logprob, init_vals, langevin_fns, num_iters = n_iters, 
-					 seed = seed, num_samples = n_samples, step_size = 1e-3,
-					 init_dist='normal', init_stddev=1.0)
-	print('done langevin in', dt.datetime.now()-t,'\n')
+	samps = bb_mcmc(
+		logprob, init_vals, langevin_fns, num_iters=n_iters, 
+		seed=seed, num_samples=n_samples, step_size=1e-3,
+		init_dist='normal', init_stddev=1.0
+	)
+	print('done langevin in', time.time()-t,'\n')
 	allsamps.append(samps)
 
-	t = dt.datetime.now()
-	samps = bb_mcmc(logprob, init_vals, mala_fns, num_iters = n_iters, 
-					 seed = seed, num_samples = n_samples, step_size = 1e-3,
-					 init_dist='normal', init_stddev=1.0, recompute_grad=True)
-	print('done MALA in', dt.datetime.now()-t,'\n')
+	t = time.time()
+	samps = bb_mcmc(
+		logprob, init_vals, mala_fns, num_iters=n_iters, 
+		seed=seed, num_samples=n_samples, step_size=1e-3,
+		init_dist='normal', init_stddev=1.0, recompute_grad=True
+	)
+	print('done MALA in', time.time()-t,'\n')
 	allsamps.append(samps)
 	
-
-	t = dt.datetime.now()
-	samps = bb_mcmc(logprob, init_vals, rk_langevin_fns, num_iters = n_iters, 
-					 seed = seed, num_samples = n_samples, step_size = 1e-3, 
-					 init_dist='normal', init_stddev=1.0, recompute_grad=True)
-	print('done langevin_RK in', dt.datetime.now()-t,'\n')
+	t = time.time()
+	samps = bb_mcmc(
+		logprob, init_vals, rk_langevin_fns, num_iters=n_iters, 
+		seed=seed, num_samples=n_samples, step_size=1e-3, 
+		init_dist='normal', init_stddev=1.0, recompute_grad=True
+	)
+	print('done langevin_RK in', time.time()-t,'\n')
 	allsamps.append(samps)
 
 
-	t = dt.datetime.now()
-	samps = bb_mcmc(logprob, init_vals, hmc_fns, num_iters = n_iters, 
-					 proposal_iters= 5, seed = seed, num_samples = n_samples, step_size = 1e-2, 
-					 init_dist='normal', init_stddev=1.0, recompute_grad=True)
-	print('done HMC in', dt.datetime.now()-t,'\n')
+	t = time.time()
+	samps = bb_mcmc(
+		logprob, init_vals, hmc_fns, num_iters=n_iters, 
+		proposal_iters= 5, seed=seed, num_samples=n_samples, step_size=1e-2, 
+		init_dist='normal', init_stddev=1.0, recompute_grad=True
+	)
+	print('done HMC in', time.time()-t,'\n')
 	allsamps.append(samps)
 
-	t = dt.datetime.now()
-	samps = bb_mcmc(logprob, init_vals, rms_langevin_fns, num_iters = n_iters, 
-					seed = seed, num_samples = n_samples, step_size = 5e-3, 
-					 init_dist='normal', init_stddev=1.0, beta=0.99)
-	print('done rms in', dt.datetime.now()-t,'\n')
+	t = time.time()
+	samps = bb_mcmc(
+		logprob, init_vals, rms_langevin_fns, num_iters=n_iters, 
+		seed = seed, num_samples = n_samples, step_size=5e-3, 
+		init_dist='normal', init_stddev=1.0, beta=0.99
+	)
+	print('done rms in', time.time()-t,'\n')
 	allsamps.append(samps)
 
-	t = dt.datetime.now()
-	samps = bb_mcmc(logprob, init_vals, rwmh_fns, num_iters = n_iters, 
-					 seed = seed, num_samples = n_samples, step_size = 0.05, 
-					 init_dist='normal', init_stddev=1.0, recompute_grad=True)
-	print('done rwmh in', dt.datetime.now()-t,'\n')
+	t = time.time()
+	samps = bb_mcmc(
+		logprob, init_vals, rwmh_fns, num_iters=n_iters, 
+		seed=seed, num_samples=n_samples, step_size=0.05, 
+		init_dist='normal', init_stddev=1.0, recompute_grad=True,
+	)
+	print('done rwmh in', time.time()-t,'\n')
 	allsamps.append(samps)
 
 	#====== Plotting =======
 
 	lims = [-5,5]
-	names = ['langevin', 'MALA', 'langevin_RK', 'HMC', 'RMS langevin', 'RWMH']
+	names = [
+		'langevin',
+		'MALA',
+		'langevin_RK',
+		'HMC',
+		'RMS langevin',
+		'RWMH'
+	]
 	cols = 2
 	rows = math.ceil(len(names) / cols)
 	idxs = itertools.product(range(rows), range(cols))
 	f, axes = plt.subplots(rows, cols, sharex=True, figsize=(12, 8))
 	for i, (name, samps, (r,c)) in enumerate(zip(names, allsamps, idxs)):
+		print(samps.shape)
 		sns.distplot(samps, bins=500, kde=False, ax=axes[r,c])
 		axb = axes[r,c].twinx()
 		axb.scatter(samps, jnp.ones(len(samps)), alpha=0.1, marker='x', color='red')

--- a/examples/shallow/mcmc_2d.py
+++ b/examples/shallow/mcmc_2d.py
@@ -5,13 +5,19 @@ import jax.numpy as np
 import jax.scipy.stats.multivariate_normal as mvn
 
 import itertools, math
-import datetime as dt
+import time
 from matplotlib import pyplot as plt
 import seaborn as sns
 
-from jax_bayes.mcmc import (langevin_fns, mala_fns, rk_langevin_fns,
-							hmc_fns, rwmh_fns, rms_langevin_fns)
-from jax_bayes.mcmc import bb_mcmc
+from jax_bayes.mcmc import (
+	langevin_fns,
+	mala_fns,
+	rk_langevin_fns,
+	hmc_fns,
+	rms_langevin_fns,
+	rwmh_fns
+)
+from jax_bayes.mcmc import blackbox_mcmc as bb_mcmc
 
 def make_logprob():
 
@@ -49,52 +55,54 @@ def main():
 
 	#====== Tests =======
 
-	t = dt.datetime.now()
+	t = time.time()
 	print('running 2d tests ...')
-	samps = bb_mcmc(logprob, init_vals, langevin_fns, num_iters = n_iters, 
-				num_samples = n_samples, seed=0, step_size = 0.05, 
-				init_dist='uniform', init_stddev=5.0)
-	print('done langevin in', dt.datetime.now()-t,'\n')
+	samps = bb_mcmc(
+		logprob, init_vals, langevin_fns, num_iters=n_iters, 
+		num_samples=n_samples, seed=0, step_size=0.05, 
+		init_dist='uniform', init_stddev=5.0)
+	print('done langevin in', time.time()-t,'\n')
 	allsamps.append(samps)
 
-
-
-	t = dt.datetime.now()
-	samps = bb_mcmc(logprob, init_vals, mala_fns, num_iters = n_iters, 
-				num_samples = n_samples, seed=0, step_size = 0.05, 
-				init_dist='uniform', init_stddev=5.0, recompute_grad=True)
-	print('done MALA in', dt.datetime.now()-t,'\n')
+	t = time.time()
+	samps = bb_mcmc(
+		logprob, init_vals, mala_fns, num_iters=n_iters, 
+		num_samples=n_samples, seed=0, step_size=0.05, 
+		init_dist='uniform', init_stddev=5.0, recompute_grad=True)
+	print('done MALA in', time.time()-t,'\n')
 	allsamps.append(samps)
 
 	
-	t = dt.datetime.now()
-	samps = bb_mcmc(logprob, init_vals, rk_langevin_fns, num_iters = n_iters, 
-				num_samples = n_samples, seed=0, step_size = 0.05, 
-				init_dist='uniform', init_stddev=5.0, recompute_grad=True)
-	print('done langevin_RK in', dt.datetime.now()-t,'\n')
+	t = time.time()
+	samps = bb_mcmc(
+		logprob, init_vals, rk_langevin_fns, num_iters=n_iters, 
+		num_samples=n_samples, seed=0, step_size=0.05, 
+		init_dist='uniform', init_stddev=5.0, recompute_grad=True)
+	print('done langevin_RK in', time.time()-t,'\n')
 	allsamps.append(samps)
 
-	t = dt.datetime.now()
-	samps = bb_mcmc(logprob, init_vals, hmc_fns, num_iters = n_iters//5, 
-				proposal_iters = 5, num_samples = n_samples, seed=0, step_size = 0.05, 
-				init_dist='uniform', init_stddev=5.0, recompute_grad=True)
-	print('done HMC in', dt.datetime.now()-t,'\n')
+	t = time.time()
+	samps = bb_mcmc(
+		logprob, init_vals, hmc_fns, num_iters=n_iters//5, 
+		proposal_iters = 5, num_samples=n_samples, seed=0, step_size=0.05,
+		init_dist='uniform', init_stddev=5.0, recompute_grad=True)
+	print('done HMC in', time.time()-t,'\n')
 	allsamps.append(samps)
 
-	t = dt.datetime.now()
-	samps = bb_mcmc(logprob, init_vals, rms_langevin_fns, num_iters = n_iters, 
-				num_samples = n_samples, seed=0, step_size = 1e-3, #1e-3 
+	t = time.time()
+	samps = bb_mcmc(logprob, init_vals, rms_langevin_fns, num_iters=n_iters, 
+				num_samples=n_samples, seed=0, step_size=1e-3, #1e-3 
 				beta=0.99, eps=1e-5,
 				init_dist='uniform', init_stddev=5.0)
-	print('done rms_langevin in', dt.datetime.now()-t,'\n')
+	print('done rms_langevin in', time.time()-t,'\n')
 	allsamps.append(samps)
 
 
-	t = dt.datetime.now()
-	samps = bb_mcmc(logprob, init_vals, rwmh_fns, num_iters = n_iters, 
-				num_samples = n_samples, seed=0, step_size = 0.05, 
+	t = time.time()
+	samps = bb_mcmc(logprob, init_vals, rwmh_fns, num_iters=n_iters, 
+				num_samples=n_samples, seed=0, step_size=0.05, 
 				init_dist='uniform', init_stddev=5.0, recompute_grad=True)
-	print('done RW MH in' , dt.datetime.now()-t,'\n')
+	print('done RW MH in' , time.time()-t,'\n')
 	allsamps.append(samps)
 
 
@@ -138,12 +146,8 @@ def main():
 		ax.set_ylim(-5, 7)
 		ax.set_xticks([])
 		ax.set_yticks([])
-	
 
 	plt.show()
-
-
-
 
 if __name__ == '__main__':
 	main()

--- a/jax_bayes/__init__.py
+++ b/jax_bayes/__init__.py
@@ -4,7 +4,7 @@ from jax_bayes import mcmc
 from jax_bayes import variational
 from jax_bayes import utils
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"
 
 __all__ = (
     "mcmc",

--- a/jax_bayes/mcmc/__init__.py
+++ b/jax_bayes/mcmc/__init__.py
@@ -5,6 +5,6 @@ from .sampler_fns import hmc_fns
 from .sampler_fns import rms_langevin_fns
 from .sampler_fns import rwmh_fns
 
-from .utils import bb_mcmc
+from .utils import blackbox_mcmc, init_distributions
 
-from .sampler import sampler
+from .sampler import sampler, SamplerState, SamplerKeys

--- a/jax_bayes/mcmc/sampler.py
+++ b/jax_bayes/mcmc/sampler.py
@@ -2,12 +2,23 @@ from collections import namedtuple
 import functools
 
 import jax
+import jax.numpy as jnp
 from jax._src.util import partial, safe_zip, safe_map, unzip2
-from jax._src.tree_util import tree_flatten, tree_unflatten, register_pytree_node
+from jax._src.tree_util import (
+    tree_flatten,
+    tree_unflatten,
+    register_pytree_node,
+    tree_multimap
+)
+
+from jax.tree_util import tree_map, tree_leaves
 
 
 map = safe_map
 zip = safe_zip
+
+def sum_tree_leaves(tree):
+    return sum(leaf for leaf in tree_leaves(tree))
 
 
 # from jax.experimental.optimizers.py:
@@ -29,7 +40,20 @@ key_flatten_fn = lambda xs: ((xs.keys,), (1,)) #make the (1,) an empty tuple
 key_unflatten_fn = lambda data, xs: SamplerKeys(xs[0])
 register_pytree_node(SamplerKeys, key_flatten_fn, key_unflatten_fn)
 
-def sampler(samp_maker):
+SamplerFns = namedtuple("SamplerFns", 
+    ['init', 'propose', 'accept', 'update', 'get_params']
+)
+
+def check_equal_pytrees(tree1, tree2, prefix=""):
+    if tree1 != tree2: #compares tree defs of the two trees
+        msg = (prefix +
+               "Passed a gradient tree that did "
+               "not match the parameter tree structure with which it was "
+               "initialized: parameter tree {} and grad tree {}.")
+        raise TypeError(msg.format(tree2, tree1))
+
+
+def sampler(sampler_builder):
     """Decorator to make an sampler defined for arrays generalize to containers.
 
     With this decorator, you can write init, propose, update, and get_params functions that
@@ -38,16 +62,16 @@ def sampler(samp_maker):
     sampler_fns.py for examples.
 
     Args:
-        samp_maker: a function that returns an ``(init, propose, update, get_params)``
+        sampler_builder: a function that returns an ``(init, propose, update, get_params)``
             triple of functions that might only work with ndarrays, as per
 
     Returns:
         An ``(init, propose, update, get_params)`` triple of functions that work on
         arbitrary pytrees.
     """
-    @functools.wraps(samp_maker)
-    def tree_samp_maker(*args, **kwargs):
-        init, propose, update, get_params, init_key = samp_maker(*args, **kwargs)
+    @functools.wraps(sampler_builder)
+    def tree_sampler_builder(*args, **kwargs):
+        init, propose, log_proposal, update, get_params, init_key = sampler_builder(*args, **kwargs)
 
         @functools.wraps(init)
         def tree_init(x0_tree):
@@ -59,7 +83,8 @@ def sampler(samp_maker):
             return SamplerState(states_flat, tree, subtrees), SamplerKeys(initial_keys)
 
         @functools.wraps(propose)
-        def tree_propose(i, grad_tree, samp_state, samp_keys):
+        # def tree_propose(i, grad_tree, samp_state, samp_keys):
+        def tree_propose(i, grad_tree, samp_state, samp_keys, **kwargs):
             states_flat, tree, subtrees = samp_state
             keys = samp_keys
             grad_flat, tree2 = tree_flatten(grad_tree)
@@ -70,6 +95,8 @@ def sampler(samp_maker):
                 raise TypeError(msg.format(tree, tree2))
             states = map(tree_unflatten, subtrees, states_flat)
             keys, keys_meta = tree_flatten(keys)
+
+            _propose = lambda g, x, k: propose(i, g, x, k, **kwargs)
             new_states, new_keys = unzip2(map(partial(propose, i), grad_flat, states, keys))
             new_states_flat, subtrees2 = unzip2(map(tree_flatten, new_states))
             for subtree, subtree2 in zip(subtrees, subtrees2):
@@ -80,39 +107,143 @@ def sampler(samp_maker):
 
             return SamplerState(new_states_flat, tree, subtrees), SamplerKeys(new_keys)
 
+        """ it would make more sense for this to accept 
+            - state (could be (x,) or (x,r), etc.)
+            - state grads
+            - prop state
+            - prop grads
+            since this summarizes all(?) the information of the sampler
+        """    
+
+        # def tree_accept(i, logp, logp_prop, trees, prop_trees, samp_keys):
+        #     # can you expose this to the user as a sort of "un-tree-ified" function?
+        #     # check that all trees in `trees` are the same
+        #     # check that all trees in `prop_trees` are the same
+        #     assert len(trees) == len(prop_trees)
+
+        #     # compute logQ(y|x)
+        #     logq_prop = sum_tree_leaves(
+        #         tree_multimap(partial(log_proposal, i), *trees, *prop_trees)
+        #     ) 
+        #     # compute #logQ(x|y)
+        #     logq_x = sum_tree_leaves(
+        #         tree_multimap(partial(log_proposal, i), *prop_trees, *trees)
+        #     ) 
+            
+        #     # compute log_alpha = log(P(xprop)/P(x) * Q(x|xprop)/Q(xprop|x))
+        #     log_alpha = logp_prop + logq_x - logp - logq_prop
+            
+        #     # split a single key from the tree keys for the global acceptance step
+        #     samp_keys_flat, samp_keys_meta = tree_flatten(samp_keys)
+        #     global_key, next_key = jax.random.split(samp_keys_flat[0])
+        #     samp_keys_flat[0] = next_key
+            
+        #     # perform global acceptance step (sample accept/reject for each tree)
+        #     # not each leaf of each tree
+        #     U = jax.random.uniform(global_key, (logp.shape[0],))
+        #     accept_idxs = jnp.log(U) < log_alpha
+            
+        #     return accept_idxs, SamplerKeys(samp_keys_flat)
+
+        def tree_accept(
+            i,
+            logp,
+            logp_prop,
+            grad_tree,
+            state,
+            prop_grad_tree,
+            prop_state,
+            samp_keys
+        ):
+            # can you expose this to the user as a sort of "un-tree-ified" function?
+            # check that all trees in `trees` are the same
+            # check that all trees in `prop_trees` are the same
+            # assert len(trees) == len(prop_trees)
+            # assert grad_treedef == grad
+
+            states_flat, tree, subtrees = state
+            grad_flat, tree2 = tree_flatten(grad_tree)
+
+            prop_states_flat, prop_tree, prop_subtrees = prop_state
+            prop_grad_flat, prop_tree2 = tree_flatten(prop_grad_tree)
+            # could check that tree2 == prop_tree2
+
+            # TRIPLE CHECK THIS ORDERING w.r.t. THE SIGNATURE OF LOG_PROPOSAL
+            # compute logQ(xprop|x)
+            # logq_prop = sum_tree_leaves(
+            #     tree_multimap(partial(log_proposal, i), 
+            #         grad_flat, states_flat, prop_grad_flat, prop_states_flat
+            #     )
+            # )
+            # # compute #logQ(x|xprop)
+            # logq_x = sum_tree_leaves(
+            #     tree_multimap(partial(log_proposal, i), 
+            #         prop_grad_flat, prop_states_flat, grad_flat, states_flat
+            #     )
+            # ) 
+            logq_prop = sum(
+                map(partial(log_proposal, i), 
+                    grad_flat, states_flat, prop_grad_flat, prop_states_flat
+                )
+            )
+            # compute #logQ(x|xprop)
+            logq_x = sum(
+                map(partial(log_proposal, i), 
+                    prop_grad_flat, prop_states_flat, grad_flat, states_flat
+                )
+            ) 
+            
+            # compute log_alpha = log(P(xprop)/P(x) * Q(x|xprop)/Q(xprop|x))
+            log_alpha = logp_prop + logq_x - logp - logq_prop
+            
+            # split a single key from the tree keys for the global acceptance step
+            samp_keys_flat, samp_keys_meta = tree_flatten(samp_keys)
+            global_key, next_key = jax.random.split(samp_keys_flat[0])
+            samp_keys_flat[0] = next_key
+            
+            # perform global acceptance step (sample accept/reject for each tree)
+            # not each leaf of each tree
+            U = jax.random.uniform(global_key, (logp.shape[0],))
+            accept_idxs = jnp.log(U) < log_alpha
+            
+            return accept_idxs, SamplerKeys(samp_keys_flat)
+
         @functools.wraps(update)
-        def tree_update(i, logp_x, logp_xprop,
-                        grad_tree, samp_state,
-                        prop_grad_tree, prop_samp_state,
-                        samp_keys):
+        def tree_update(
+            i, 
+            accept_idxs, 
+            grad_tree,
+            samp_state, 
+            prop_grad_tree,
+            prop_samp_state,
+            samp_keys
+        ):
             """
             logp_x and logp_xprop are (N,) arrays (i.e. arrays of scalars)
             of log probs to be passed to every call of update.
             """
             keys = samp_keys
+
             states_flat, tree, subtrees = samp_state
             grad_flat, tree2 = tree_flatten(grad_tree)
-            if tree2 != tree: #compares tree defs of the two trees
-                msg = ("sampler update function was passed a gradient tree that did "
-                       "not match the parameter tree structure with which it was "
-                       "initialized: parameter tree {} and grad tree {}.")
-                raise TypeError(msg.format(tree, tree2))
-
+            # compare state grad tree and state tree
+            check_equal_pytrees(tree, tree2, prefix='state tree vs grad tree: ')
+            
             prop_states_flat, prop_tree, prop_subtrees = prop_samp_state
             prop_grad_flat, prop_tree2 = tree_flatten(prop_grad_tree)
-            if prop_tree2 != tree: #compares tree defs of the two trees
-                msg = ("sampler update function was passed a gradient tree that did "
-                       "not match the parameter tree structure with which it was "
-                       "initialized: parameter tree {} and grad tree {}.")
-                raise TypeError(msg.format(tree, prop_tree2))
+            # compare proposal tree and state tree
+            check_equal_pytrees(prop_tree, tree, prefix='prop state tree vs grad tree: ')
+
+            # compare proposal grad tree and state grad tree 
+            check_equal_pytrees(prop_tree2, prop_tree, prefix='prop state tree vs prop grad tree: ')            
 
             states = map(tree_unflatten, subtrees, states_flat)
             prop_states = map(tree_unflatten, prop_subtrees, prop_states_flat)
             keys, keys_meta = tree_flatten(keys)
-            new_states, new_keys = unzip2(map(partial(update, i, logp_x, logp_xprop),
-                                              grad_flat, states,
-                                              prop_grad_flat, prop_states,
-                                              keys))
+            new_states, new_keys= unzip2(
+                map(partial(update, i, accept_idxs),
+                grad_flat, states, prop_grad_flat, prop_states, keys)
+            )
             new_states_flat, subtrees2 = unzip2(map(tree_flatten, new_states))
             for subtree, subtree2 in zip(subtrees, subtrees2):
                 if subtree2 != subtree:
@@ -123,11 +254,14 @@ def sampler(samp_maker):
             return SamplerState(new_states_flat, tree, subtrees), SamplerKeys(new_keys)
 
         @functools.wraps(get_params)
-        def tree_get_params(samp_state):
+        def tree_get_params(samp_state, **kwargs):
             states_flat, tree, subtrees = samp_state
             states = map(tree_unflatten, subtrees, states_flat)
-            params = map(get_params, states)
+            # params = map(get_params, states)
+            # _get_params = lambda s: get_params(s, **kwargs)
+            # params = map(_get_params, states)
+            params = (get_params(s, **kwargs) for s in states)
             return tree_unflatten(tree, params)
 
-        return tree_init, tree_propose, tree_update, tree_get_params
-    return tree_samp_maker
+        return SamplerFns(tree_init, tree_propose, tree_accept, tree_update, tree_get_params)
+    return tree_sampler_builder

--- a/jax_bayes/mcmc/sampler_fns.py
+++ b/jax_bayes/mcmc/sampler_fns.py
@@ -1,13 +1,17 @@
-"""Sampler functions for use with jax-bayes."""
-
 import math
 
 import jax
 import jax.numpy as jnp
 from jax.experimental.optimizers import make_schedule
 
+# from sampler import sampler
 from .sampler import sampler
 from .utils import init_distributions
+
+centered_uniform = \
+    lambda *args, **kwargs: jax.random.uniform(*args, **kwargs) - 0.5
+init_distributions = dict(normal=jax.random.normal,
+                          uniform=centered_uniform)
 
 def match_dims(src, target, start_dim=1):
     """
@@ -18,8 +22,14 @@ def match_dims(src, target, start_dim=1):
     return jnp.expand_dims(src, new_dims)
 
 @sampler
-def langevin_fns(base_key, num_samples=10, step_size=1e-3, init_stddev=0.1,
-                 init_dist='normal'):
+def langevin_fns(
+    base_key,
+    num_samples=10,
+    step_size=1e-3,
+    noise_scale=1.0,
+    init_stddev=0.1,
+    init_dist='normal'
+):
     """Constructs sampler functions for the Unadjusted Langevin Algorithm.
     See e.g. https://arxiv.org/pdf/1605.01559.pdf.
 
@@ -37,10 +47,15 @@ def langevin_fns(base_key, num_samples=10, step_size=1e-3, init_stddev=0.1,
     Returns:
         sampler function tuple (init, propose, update, get_params)
     """
+
     step_size = make_schedule(step_size)
+    noise_scale = make_schedule(noise_scale)
 
     if isinstance(init_dist, str):
         init_dist = init_distributions[init_dist]
+
+    def log_proposal(*args):
+        return jnp.zeros(num_samples)
 
     def init(x0, key):
         init_key, next_key = jax.random.split(key)
@@ -49,23 +64,30 @@ def langevin_fns(base_key, num_samples=10, step_size=1e-3, init_stddev=0.1,
         x = init_dist(init_key, (num_samples,) + x0.shape)
         return x0 + init_stddev * x, next_key
 
-    def propose(i, g, x, key):
+    def propose(i, g, x, key, **kwargs):
         key, next_key = jax.random.split(key)
         Z = jax.random.normal(key, x.shape)
-        return x + step_size(i) * g + math.sqrt(2 * step_size(i)) * Z, next_key
+        return x + step_size(i) * g + \
+            math.sqrt(2 * step_size(i) * noise_scale(i)) * Z, next_key
 
-    def update(i, logp_x, logp_xprop, g, x, gprop, xprop, key):
+    def update(i, accept_idxs, g, x, gprop, xprop, key):
         key, next_key = jax.random.split(key)
         return xprop, next_key
 
     def get_params(x):
         return x
 
-    return init, propose, update, get_params, base_key
+    return init, propose, log_proposal, update, get_params, base_key
 
 @sampler
-def mala_fns(base_key, num_samples=10, step_size=1e-3,
-             init_stddev=0.1, init_dist='normal'):
+def mala_fns(
+    base_key,
+    num_samples=10,
+    step_size=1e-3,
+    init_stddev=0.1,
+    noise_scale=1.0,
+    init_dist='normal'
+):
     """Constructs sampler functions for the Metropolis Adjusted Langevin Algorithm.
     See e.g. http://probability.ca/jeff/ftpdir/lang.pdf
 
@@ -84,15 +106,19 @@ def mala_fns(base_key, num_samples=10, step_size=1e-3,
         sampler function tuple (init, propose, update, get_params)
     """
     step_size = make_schedule(step_size)
+    noise_scale = make_schedule(noise_scale)
 
     if isinstance(init_dist, str):
         init_dist = init_distributions[init_dist]
 
-    def log_proposal(i, y, x, dx):
-        #computes log q(y|x)
-        return - 0.5 * jnp.sum(jnp.square((y - x - step_size(i) * dx)) \
-                / math.sqrt(2 *step_size(i)))
-    log_proposal = jax.vmap(log_proposal, in_axes=(None, 0, 0, 0))
+    # def log_proposal(i, x, dx, xprop, dxprop):
+    def log_proposal(i, g, x, gprop, xprop): #grads come first
+        #computes log q(xprop|x)
+        x, = x
+        xprop, = xprop
+        return - 0.5 * jnp.sum(jnp.square((xprop - x - step_size(i) * g)) \
+                / math.sqrt(2 *step_size(i) * noise_scale(i)))
+    log_proposal = jax.vmap(log_proposal, in_axes=(None, 0, 0, 0, 0))
 
     def init(x0, key):
         init_key, next_key = jax.random.split(key)
@@ -101,33 +127,33 @@ def mala_fns(base_key, num_samples=10, step_size=1e-3,
         x = init_dist(init_key, (num_samples,) + x0.shape)
         return x0 + init_stddev * x, next_key
 
-    def propose(i, g, x, key):
+    def propose(i, g, x, key, **kwargs):
         key, next_key = jax.random.split(key)
         Z = jax.random.normal(key, x.shape)
-        return x + step_size(i) * g + math.sqrt(2 * step_size(i)) * Z, next_key
+        # return x + step_size(i) * g + math.sqrt(2 * step_size(i)) * Z, next_key
+        return x + step_size(i) * g + math.sqrt(2 * step_size(i)) * noise_scale(i) * Z, next_key
 
-    def update(i, logp_x, logp_xprop, g, x, gprop, xprop, key):
-        key, next_key = jax.random.split(key)
-        U = jax.random.uniform(key, (x.shape[0],))
-
-        log_alpha = (logp_xprop + log_proposal(i, x, xprop, gprop)
-                     - logp_x - log_proposal(i, xprop, x, g))
-
-        accept_idxs = jnp.log(U) < log_alpha
+    def update(i, accept_idxs, g, x, gprop, xprop, key):
+        """ if the state had additional data, you would need to accept them too"""
         accept_idxs = match_dims(accept_idxs, x)
         mask = accept_idxs.astype(jnp.float32)
 
         xnext = x * (1.0 - mask) + xprop * mask
-        return xnext, next_key
+        return xnext, key
 
     def get_params(x):
         return x
 
-    return init, propose, update, get_params, base_key
+    return init, propose, log_proposal, update, get_params, base_key
 
 @sampler
-def rk_langevin_fns(base_key, num_samples=10, step_size=1e-3,
-                    init_stddev=0.1, init_dist='normal'):
+def rk_langevin_fns(
+    base_key,
+    num_samples=10,
+    step_size=1e-3,
+    init_stddev=0.1,
+    init_dist='normal'
+):
     """Constructs sampler functions for a Stochastic Runge Kutta integrator of the
     continuous-time Langevin dynamics.
 
@@ -152,10 +178,11 @@ def rk_langevin_fns(base_key, num_samples=10, step_size=1e-3,
         sampler function tuple (init, propose, update, get_params)
     """
     step_size = make_schedule(step_size)
-
     if isinstance(init_dist, str):
-        init_dist = init_distributions[init_dist]
+            init_dist = init_distributions[init_dist]
 
+    def log_proposal(*args):
+        return jnp.zeros(num_samples)
 
     def init(x0, key):
         init_key, next_key = jax.random.split(key)
@@ -164,7 +191,7 @@ def rk_langevin_fns(base_key, num_samples=10, step_size=1e-3,
         x = init_dist(init_key, (num_samples,) + x0.shape)
         return x0 + init_stddev * x, next_key
 
-    def propose(i, g, x, key):
+    def propose(i, g, x, key, **kwargs):
         h = step_size(i)
         root_h = math.sqrt(h)
 
@@ -174,10 +201,9 @@ def rk_langevin_fns(base_key, num_samples=10, step_size=1e-3,
         S = match_dims(S, x)
 
         K1 = x + h * g + (W - root_h * S) * math.sqrt(2)
-
         return K1, key
 
-    def update(i, logp_x, logp_xprop, g, x, gprop, xprop, key):
+    def update(i, accept_idxs, g, x, gprop, xprop, key):
         h = step_size(i)
         root_h = math.sqrt(h)
 
@@ -188,15 +214,20 @@ def rk_langevin_fns(base_key, num_samples=10, step_size=1e-3,
 
         K2 = h * gprop + (W + root_h * S) * math.sqrt(2)
         return  0.5 * x + 0.5 * (xprop + K2), next_key
-
+    
     def get_params(x):
         return x
 
-    return init, propose, update, get_params, base_key
+    return init, propose, log_proposal, update, get_params, base_key
 
 @sampler
-def hmc_fns(base_key, num_samples=10, step_size=1e-3,
-            init_stddev=0.1, init_dist='normal'):
+def hmc_fns(
+    base_key,
+    num_samples=10,
+    step_size=1e-3,
+    init_stddev=0.1,
+    init_dist='normal'
+):
     """Constructs sampler functions for the Hamiltonia Monte Carlo algorithm.
     See e.g. http://probability.ca/jeff/ftpdir/lang.pdf
 
@@ -215,13 +246,17 @@ def hmc_fns(base_key, num_samples=10, step_size=1e-3,
         sampler function tuple (init, propose, update, get_params)
     """
     step_size = make_schedule(step_size)
-
     if isinstance(init_dist, str):
-        init_dist = init_distributions[init_dist]
-
-    @jax.vmap
+            init_dist = init_distributions[init_dist]
+    
     def dot_product(x, y):
         return jnp.sum(x * y)
+
+    def log_proposal(i, g, x, gprop, xprop): #grads come first
+        #computes log q(xprop|x)
+        x,r = x
+        return dot_product(r, r)
+    log_proposal = jax.vmap(log_proposal, in_axes=(None, 0, 0, 0, 0))
 
     def init(x0, key):
         init_key, R_key, next_key = jax.random.split(key, 3)
@@ -232,35 +267,30 @@ def hmc_fns(base_key, num_samples=10, step_size=1e-3,
         R = jax.random.normal(R_key, (num_samples,) + x0.shape)
         return (x0 + init_stddev * x, R), next_key
 
-    def propose(i, g, x, key):
+    def propose(i, g, x, key, is_final=False):
         """
-        iterate this several times for multistep leapfrog integrator. Note
-        the final update for rprop is in the update
+        iterate this several times for multistep leapfrog integrator.
+        is_final is used for the final update of leapfrog integrator, 
+            which only modifies rprop and not xprop.
         """
         next_key = key
         x, r = x
         rprop = r + 0.5 * step_size(i) * g
-        xprop = x + step_size(i) * rprop
+        if is_final:
+            xprop = x
+        else:
+            xprop = x + step_size(i) * rprop
+
         return (xprop, rprop), next_key
 
-    def update(i, logp_x, logp_xprop, g, x, gprop, xprop, key):
+    def update(i, accept_idxs, g, x, gprop, xprop, key):
         u_key, r_key, next_key = jax.random.split(key, 3)
 
         x, r = x
         xprop, rprop = xprop
-        #this is the last step of the leapfrog integrator
-        rprop = rprop + 0.5 * step_size(i) * gprop
-
-        U = jax.random.uniform(key, (x.shape[0],))
-
-        log_alpha = (logp_xprop + dot_product(rprop, rprop)
-                     - logp_x - dot_product(r, r))
-
-        accept_idxs = jnp.log(U) < log_alpha
 
         accept_idxs = match_dims(accept_idxs, x)
         mask = accept_idxs.astype(jnp.float32)
-
         xnext = x * (1.0 - mask) + xprop * mask
 
         #this is for the first step of the leapfrog integrator
@@ -270,12 +300,18 @@ def hmc_fns(base_key, num_samples=10, step_size=1e-3,
     def get_params(x):
         return x[0]
 
-    return init, propose, update, get_params, base_key
-
+    return init, propose, log_proposal, update, get_params, base_key
 
 @sampler
-def rms_langevin_fns(base_key, num_samples=10, step_size=1e-3, beta=0.9,
-                     eps=1e-9, init_stddev=0.1, init_dist='normal'):
+def rms_langevin_fns(
+    base_key,
+    num_samples=10,
+    step_size=1e-3,
+    beta=0.9,
+    eps=1e-9,
+    init_stddev=0.1,
+    init_dist='normal'
+):
     """Constructs sampler functions for the RMS-preconditioned Langevin algorithm.
     See e.g. https://arxiv.org/pdf/1512.07666.pdf
 
@@ -298,6 +334,10 @@ def rms_langevin_fns(base_key, num_samples=10, step_size=1e-3, beta=0.9,
     if isinstance(init_dist, str):
         init_dist = init_distributions[init_dist]
 
+
+    def log_proposal(*args): #grads come first
+        return jnp.zeros(num_samples)
+
     def init(x0, key):
         init_key, next_key = jax.random.split(key)
         if num_samples == -1:
@@ -306,8 +346,8 @@ def rms_langevin_fns(base_key, num_samples=10, step_size=1e-3, beta=0.9,
         x = init_dist(init_key, (num_samples,) + x0.shape)
         r = jnp.zeros_like(x)
         return (x0 + init_stddev * x, r), next_key
-
-    def propose(i, g, x, key):
+    
+    def propose(i, g, x, key, **kwargs):
         key, next_key = jax.random.split(key)
         x, r = x
         Z = jax.random.normal(key, x.shape)
@@ -318,21 +358,24 @@ def rms_langevin_fns(base_key, num_samples=10, step_size=1e-3, beta=0.9,
         xprop = x + ss * g + jnp.sqrt(2 * ss) * Z
 
         return (xprop, r), next_key
-
-    def update(i, logp_x, logp_xprop, g, x, gprop, xprop, key):
+    
+    def update(i, accept_idxs, g, x, gprop, xprop, key):
         key, next_key = jax.random.split(key)
         return xprop, next_key
 
     def get_params(x):
-        x, _ = x
-        return x
+        return x[0]
 
-    return init, propose, update, get_params, base_key
-
+    return init, propose, log_proposal, update, get_params, base_key
 
 @sampler
-def rwmh_fns(base_key, num_samples=10, step_size=1e-3,
-             init_stddev=0.1, init_dist='normal'):
+def rwmh_fns(
+    base_key,
+    num_samples=10,
+    step_size=1e-3,
+    init_stddev=0.1,
+    init_dist='normal'
+):
     """Constructs sampler functions for Random Walk Metropolis Hastings.
     See e.g. https://arxiv.org/pdf/1504.01896.pdf
 
@@ -351,9 +394,13 @@ def rwmh_fns(base_key, num_samples=10, step_size=1e-3,
         sampler function tuple (init, propose, update, get_params)
     """
     step_size = make_schedule(step_size)
-
     if isinstance(init_dist, str):
         init_dist = init_distributions[init_dist]
+
+    def log_proposal(*args):
+        # in this case, the proposal is symmetric, so this is correct
+        return jnp.zeros(num_samples)
+    # log_proposal = jax.vmap(log_proposal, in_axes=(None, 0, 0, 0, 0))
 
     def init(x0, key):
         init_key, next_key = jax.random.split(key)
@@ -362,25 +409,20 @@ def rwmh_fns(base_key, num_samples=10, step_size=1e-3,
         x = init_dist(init_key, (num_samples,) + x0.shape)
         return x0 + init_stddev * x, next_key
 
-    def propose(i, g, x, key):
+    def propose(i, g, x, key, **kwargs):
         key, next_key = jax.random.split(key)
         Z = jax.random.normal(key, x.shape)
         return x + step_size(i) * Z, next_key
 
-    def update(i, logp_x, logp_xprop, g, x, gprop, xprop, key):
+    def update(i, accept_idxs, g, x, gprop, xprop, key):
         key, next_key = jax.random.split(key)
-        U = jax.random.uniform(key, (x.shape[0],))
-
-        log_alpha = logp_xprop - logp_x
-
-        accept_idxs = jnp.log(U) < log_alpha
+        
         accept_idxs = match_dims(accept_idxs, x)
         mask = accept_idxs.astype(jnp.float32)
-
         xnext = x * (1.0 - mask) + xprop * mask
         return xnext, next_key
 
     def get_params(x):
         return x
 
-    return init, propose, update, get_params, base_key
+    return init, propose, log_proposal, update, get_params, base_key

--- a/jax_bayes/mcmc/utils.py
+++ b/jax_bayes/mcmc/utils.py
@@ -14,8 +14,17 @@ init_distributions = dict(normal=jax.random.normal,
 elementwise_grad = lambda f: jax.vmap(grad(f))
 elementwise_value_and_grad = lambda f: jax.vmap(value_and_grad(f))
 
-def bb_mcmc(logprob, x0, sampler_fn, num_iters=1000, proposal_iters=1,
-            seed=None, recompute_grad=False, use_jit=True, **sampler_args):
+def blackbox_mcmc(
+    logprob,
+    x0,
+    sampler_fn,
+    num_iters=1000,
+    proposal_iters=1,
+    seed=None,
+    recompute_grad=False,
+    use_jit=True,
+    **sampler_args
+):
     """ A single-function black-box sampler abstracting the various pieces
     of the functional sampler methodologies.
 
@@ -40,30 +49,35 @@ def bb_mcmc(logprob, x0, sampler_fn, num_iters=1000, proposal_iters=1,
     seed = int(time.time() * 1000) if seed is None else seed
     init_key = jax.random.PRNGKey(seed)
 
-    sampler_init, sampler_propose, sampler_update, sampler_get_params = \
-        sampler_fn(init_key, **sampler_args)
-
-    sampler_state, sampler_keys = sampler_init(x0)
+    sampler = sampler_fn(init_key, **sampler_args)
+    sampler_state, sampler_keys = sampler.init(x0)
 
     def _step(i, state, keys):
-        x = sampler_get_params(state)
+        x = sampler.get_params(state)
         fx, dx = g(x)
 
-        prop_state, keys = sampler_propose(i, dx, state, keys)
+        prop_state, keys = sampler.propose(i, dx, state, keys)
+        x_prop = sampler.get_params(prop_state)
         if recompute_grad:
-            x_prop = sampler_get_params(prop_state)
             fx_prop, dx_prop = g(x_prop)
             for _ in range(max(proposal_iters-1, 0)):
-                prop_state, keys = sampler_propose(i, dx_prop, prop_state, keys)
-                x_prop = sampler_get_params(prop_state)
+                prop_state, keys = sampler.propose(i, dx_prop, prop_state, keys)
+                x_prop = sampler.get_params(prop_state)
+                fx_prop, dx_prop = g(x_prop)
+            if proposal_iters > 1:
+                prop_state, keys = sampler.propose(i, dx_prop, prop_state, keys, is_final=True)
+                x_prop = sampler.get_params(prop_state)
                 fx_prop, dx_prop = g(x_prop)
         else:
             fx_prop, dx_prop = fx, dx
 
-        state, keys = sampler_update(i, fx, fx_prop,
-                                     dx, state,
-                                     dx_prop, prop_state,
-                                     keys)
+        accept_idxs, keys = sampler.accept(
+            i, fx, fx_prop, dx, state, dx_prop, prop_state, keys
+        )
+
+        state, keys = sampler.update(
+            i, accept_idxs, dx, state, dx, prop_state, keys
+        )
         return state, keys
 
     if use_jit:
@@ -73,4 +87,4 @@ def bb_mcmc(logprob, x0, sampler_fn, num_iters=1000, proposal_iters=1,
         # if callback: callback(x, i, dx)
         sampler_state, sampler_keys = _step(i, sampler_state, sampler_keys)
 
-    return sampler_get_params(sampler_state)
+    return sampler.get_params(sampler_state)


### PR DESCRIPTION
This is a version update from 0.0.1 to 0.1.0 which fixes a bug in the way the Metropolis-Hastings accept/reject mechanism was implemented for pytrees. 

Specifically, in version 0.0.1, the accept/reject was performed locally for each leaf in the pytree, but now we perform a single accept/reject step globally for each sample, and apply this decision to each pytree. The former was incorrect because it was possible to have one leaf of a pytree be "accepted" and another leaf of the pytree "rejected" within the same sample. In this case, the two leaves would be generated by different dynamics, and over time the pytree will not be a true sample from the mcmc dynamics.

The API change requires an additional `accept` step which is not user-defined (this is major change from the previous version). This accept step computes a Metropolis-Hastings step using the user-provided log-proposal. The accept step has the signature
`def accept(i, logp, logp_prop, grad_tree, state, prop_grad_tree, prop_state, samp_keys)`, so we assume that all information necessary to evaluate the M-H step is contained in these data. The `update` step now takes a set of `accept_idxs` indices indicating which proposal pytrees were accepted in the `accept` step.

All previously-implemented MCMC samplers are now implemented in the new API. The changes are generally small, but some additional flexibility is necessary in the `propose` step to handle the case where the proposal is changed in the `update` step.

The shallow examples are now functioning with the new API. The `deep/nn_regression` and `deep/mnist` examples work with the new API. The CIFAR10 example is *not* converted to the new API, and is broken for now. 

There are no changes to the `jax_bayes.variational` functionality.

